### PR TITLE
feat: show error feedback when processing fails

### DIFF
--- a/DropZoneView.swift
+++ b/DropZoneView.swift
@@ -45,6 +45,36 @@ struct FannedImageStack: View {
     }
 }
 
+struct ShakeEffect: GeometryEffect {
+    var shakes: CGFloat = 0
+    var animatableData: CGFloat {
+        get { shakes }
+        set { shakes = newValue }
+    }
+
+    func effectValue(size: CGSize) -> ProjectionTransform {
+        let translation = 6 * sin(shakes * .pi * 2)
+        return ProjectionTransform(CGAffineTransform(translationX: translation, y: 0))
+    }
+}
+
+struct ErrorIconView: View {
+    @State private var shakeCount: CGFloat = 0
+
+    var body: some View {
+        Image(systemName: "exclamationmark.triangle.fill")
+            .font(.system(size: 42))
+            .foregroundColor(Color(red: 0.91, green: 0.66, blue: 0.09))
+            .shadow(color: Color(red: 0.91, green: 0.66, blue: 0.09).opacity(0.5), radius: 8, x: 0, y: 0)
+            .modifier(ShakeEffect(shakes: shakeCount))
+            .onAppear {
+                withAnimation(.easeOut(duration: 0.4)) {
+                    shakeCount = 3
+                }
+            }
+    }
+}
+
 struct DropZoneView: View {
     @Binding var showSettings: Bool
     @StateObject var processor = ImageProcessor()
@@ -115,22 +145,29 @@ struct DropZoneView: View {
                             let elapsedTime = timeline.date.timeIntervalSince(processor.processingStartTime)
                             let dropTime = elapsedTime.truncatingRemainder(dividingBy: 2.0)
                             let successTime = timeline.date.timeIntervalSince(processor.successStartTime)
+                            let errorTime = timeline.date.timeIntervalSince(processor.errorStartTime)
 
                             let isSuccess = processor.isSuccess
-                            let rippleTime = isSuccess ? successTime : dropTime
-                            let amplitude: Float = isSuccess ? 1.5 : 12.0
-                            let frequency: Float = isSuccess ? 20.0 : 15.0
-                            let decay: Float     = isSuccess ? 5.0 : 8.0
-                            let speed: Float     = isSuccess ? 900.0 : 1000.0
+                            let isError = processor.isError
+                            let rippleTime = isSuccess ? successTime : (isError ? errorTime : dropTime)
+                            let amplitude: Float = isSuccess ? 1.5 : (isError ? 1.2 : 12.0)
+                            let frequency: Float = isSuccess ? 20.0 : (isError ? 22.0 : 15.0)
+                            let decay: Float     = isSuccess ? 5.0 : (isError ? 7.0 : 8.0)
+                            let speed: Float     = isSuccess ? 900.0 : (isError ? 800.0 : 1000.0)
 
                             ZStack {
                                 // Background
                                 ZStack {
                                     Color.black
                                     Circle()
-                                        .fill(Color(red: 0.20, green: 0.764, blue: 0.388).opacity(isSuccess ? 0.6 : 0.3))
+                                        .fill(
+                                            (isError
+                                                ? Color(red: 0.91, green: 0.66, blue: 0.09)
+                                                : Color(red: 0.20, green: 0.764, blue: 0.388))
+                                            .opacity(isSuccess ? 0.6 : (isError ? 0.5 : 0.3))
+                                        )
                                         .frame(width: 160)
-                                        .blur(radius: 40)
+                                        .blur(radius: isError ? 35 : 40)
                                         .offset(x: -40, y: -20)
                                     Circle()
                                         .fill(Color.white.opacity(0.15))
@@ -164,6 +201,16 @@ struct DropZoneView: View {
                                             .foregroundColor(.white)
                                             .padding(.bottom, 16)
                                             .transition(.opacity)
+                                    } else if processor.isError {
+                                        ErrorIconView()
+                                            .transition(.scale.combined(with: .opacity))
+
+                                        Text("FAILED")
+                                            .font(.system(size: 12, weight: .bold, design: .rounded))
+                                            .tracking(2.0)
+                                            .foregroundColor(.white)
+                                            .padding(.bottom, 16)
+                                            .transition(.opacity)
                                     } else {
                                         FannedImageStack(images: processor.processingImages)
                                             .transition(.scale.combined(with: .opacity))
@@ -177,6 +224,7 @@ struct DropZoneView: View {
                                     }
                                 }
                                 .animation(.spring(response: 0.10, dampingFraction: 0.65), value: processor.isSuccess)
+                                .animation(.spring(response: 0.08, dampingFraction: 0.70), value: processor.isError)
                             }
                             .layerEffect(
                                 ShaderLibrary.Ripple(
@@ -203,7 +251,16 @@ struct DropZoneView: View {
             .padding(2)
             .overlay(
                 RoundedRectangle(cornerRadius: 12)
-                    .stroke(processor.isProcessing ? (processor.isSuccess ? Color.green.opacity(0.4) : Color.white.opacity(0.3)) : Color.white.opacity(0.15), style: StrokeStyle(lineWidth: 2, dash: [6, 6]))
+                    .stroke(
+                        processor.isProcessing
+                            ? (processor.isSuccess
+                                ? Color.green.opacity(0.4)
+                                : (processor.isError
+                                    ? Color(red: 0.91, green: 0.66, blue: 0.09).opacity(0.4)
+                                    : Color.white.opacity(0.3)))
+                            : Color.white.opacity(0.15),
+                        style: StrokeStyle(lineWidth: 2, dash: [6, 6])
+                    )
                     .animation(.easeInOut, value: processor.isProcessing)
             )
             .padding(12)

--- a/DropZoneView.swift
+++ b/DropZoneView.swift
@@ -1,6 +1,10 @@
 import SwiftUI
 import UniformTypeIdentifiers
 
+extension Color {
+    static let burritoAmber = Color(red: 0.91, green: 0.66, blue: 0.09)
+}
+
 // Fanned preview stack
 struct FannedImageStack: View {
     var images: [NSImage]
@@ -64,8 +68,8 @@ struct ErrorIconView: View {
     var body: some View {
         Image(systemName: "exclamationmark.triangle.fill")
             .font(.system(size: 42))
-            .foregroundColor(Color(red: 0.91, green: 0.66, blue: 0.09))
-            .shadow(color: Color(red: 0.91, green: 0.66, blue: 0.09).opacity(0.5), radius: 8, x: 0, y: 0)
+            .foregroundColor(.burritoAmber)
+            .shadow(color: .burritoAmber.opacity(0.5), radius: 8, x: 0, y: 0)
             .modifier(ShakeEffect(shakes: shakeCount))
             .onAppear {
                 withAnimation(.easeOut(duration: 0.4)) {
@@ -75,11 +79,147 @@ struct ErrorIconView: View {
     }
 }
 
+private struct ProcessingLayerView: View {
+    @ObservedObject var processor: ImageProcessor
+
+    var body: some View {
+        GeometryReader { geo in
+            if processor.isProcessing {
+                TimelineView(.animation(minimumInterval: 1/60)) { timeline in
+                    let elapsedTime = timeline.date.timeIntervalSince(processor.processingStartTime)
+                    let dropTime = elapsedTime.truncatingRemainder(dividingBy: 2.0)
+                    let successTime = timeline.date.timeIntervalSince(processor.successStartTime)
+                    let errorTime = timeline.date.timeIntervalSince(processor.errorStartTime)
+
+                    let isSuccess = processor.isSuccess
+                    let isError = processor.isError
+                    let rippleParams: (Double, Float, Float, Float, Float) = {
+                        if isSuccess { return (successTime, 1.5, 20.0, 5.0, 900.0) }
+                        if isError   { return (errorTime,   1.2, 22.0, 7.0, 800.0) }
+                        return (dropTime, 12.0, 15.0, 8.0, 1000.0)
+                    }()
+                    let rippleTime  = rippleParams.0
+                    let amplitude   = rippleParams.1
+                    let frequency   = rippleParams.2
+                    let decay       = rippleParams.3
+                    let speed       = rippleParams.4
+
+                    ZStack {
+                        backgroundBlobs(geo: geo, elapsedTime: elapsedTime, isError: isError, isSuccess: isSuccess)
+                        foregroundContent(isSuccess: isSuccess, isError: isError)
+                    }
+                    .layerEffect(
+                        ShaderLibrary.Ripple(
+                            .float2(Float(geo.size.width / 2), Float(geo.size.height / 2)),
+                            .float(Float(rippleTime)),
+                            .float(amplitude),
+                            .float(frequency),
+                            .float(decay),
+                            .float(speed)
+                        ),
+                        maxSampleOffset: CGSize(width: 40, height: 40),
+                        isEnabled: true
+                    )
+                }
+                .transition(.opacity)
+            }
+        }
+        .allowsHitTesting(processor.isProcessing)
+    }
+
+    @ViewBuilder
+    private func backgroundBlobs(geo: GeometryProxy, elapsedTime: TimeInterval, isError: Bool, isSuccess: Bool) -> some View {
+        ZStack {
+            Color.black
+            Circle()
+                .fill(
+                    (isError
+                        ? Color.burritoAmber
+                        : Color(red: 0.20, green: 0.764, blue: 0.388))
+                    .opacity(isSuccess ? 0.6 : (isError ? 0.5 : 0.3))
+                )
+                .frame(width: 160)
+                .blur(radius: isError ? 35 : 40)
+                .offset(x: -40, y: -20)
+            Circle()
+                .fill(Color.white.opacity(0.15))
+                .frame(width: 140)
+                .blur(radius: 40)
+                .offset(x: 50, y: 30)
+        }
+        .scaleEffect(1.2)
+        .layerEffect(
+            ShaderLibrary.modernFluid(
+                .float(elapsedTime),
+                .float2(Float(geo.size.width), Float(geo.size.height))
+            ),
+            maxSampleOffset: CGSize(width: 10, height: 10)
+        )
+    }
+
+    @ViewBuilder
+    private func foregroundContent(isSuccess: Bool, isError: Bool) -> some View {
+        VStack(spacing: 12) {
+            Spacer()
+            if isSuccess {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 42))
+                    .foregroundColor(Color(red: 0.2, green: 0.8, blue: 0.4))
+                    .shadow(color: Color(red: 0.2, green: 0.8, blue: 0.4).opacity(0.5), radius: 8, x: 0, y: 0)
+                    .transition(.scale.combined(with: .opacity))
+                Text("SUCCESS")
+                    .font(.system(size: 12, weight: .bold, design: .rounded))
+                    .tracking(2.0)
+                    .foregroundColor(.white)
+                    .padding(.bottom, 16)
+                    .transition(.opacity)
+            } else if isError {
+                ErrorIconView()
+                    .transition(.scale.combined(with: .opacity))
+                Text("FAILED")
+                    .font(.system(size: 12, weight: .bold, design: .rounded))
+                    .tracking(2.0)
+                    .foregroundColor(.white)
+                    .padding(.bottom, 16)
+                    .transition(.opacity)
+            } else {
+                FannedImageStack(images: processor.processingImages)
+                    .transition(.scale.combined(with: .opacity))
+                Text("PROCESSING \(processor.activeFormat == .png ? "PNG" : "WEBP")")
+                    .font(.system(size: 11, weight: .bold, design: .rounded))
+                    .tracking(1.5)
+                    .foregroundColor(.white.opacity(0.9))
+                    .padding(.bottom, 16)
+                    .transition(.opacity)
+            }
+        }
+        .animation(.spring(response: 0.10, dampingFraction: 0.65), value: processor.isSuccess)
+        .animation(.spring(response: 0.08, dampingFraction: 0.70), value: processor.isError)
+    }
+}
+
 struct DropZoneView: View {
     @Binding var showSettings: Bool
     @StateObject var processor = ImageProcessor()
     @State private var isTargetedPNG = false
     @State private var isTargetedWebP = false
+
+    private var borderStrokeColor: Color {
+        let isProcessing = processor.isProcessing
+        let isSuccess = processor.isSuccess
+        let isError = processor.isError
+        
+        if isProcessing {
+            if isSuccess {
+                return Color.green.opacity(0.4)
+            }
+            if isError {
+                return Color.burritoAmber.opacity(0.4)
+            }
+            return Color.white.opacity(0.3)
+        }
+        return Color.white.opacity(0.15)
+    }
     
     var body: some View {
         VStack(spacing: 0) {
@@ -139,110 +279,7 @@ struct DropZoneView: View {
                 
                 
                 // LAYER 2: COMBINED PROCESSING ZONE (Fades in when processing)
-                GeometryReader { geo in
-                    if processor.isProcessing {
-                        TimelineView(.animation(minimumInterval: 1/60)) { timeline in
-                            let elapsedTime = timeline.date.timeIntervalSince(processor.processingStartTime)
-                            let dropTime = elapsedTime.truncatingRemainder(dividingBy: 2.0)
-                            let successTime = timeline.date.timeIntervalSince(processor.successStartTime)
-                            let errorTime = timeline.date.timeIntervalSince(processor.errorStartTime)
-
-                            let isSuccess = processor.isSuccess
-                            let isError = processor.isError
-                            let rippleTime = isSuccess ? successTime : (isError ? errorTime : dropTime)
-                            let amplitude: Float = isSuccess ? 1.5 : (isError ? 1.2 : 12.0)
-                            let frequency: Float = isSuccess ? 20.0 : (isError ? 22.0 : 15.0)
-                            let decay: Float     = isSuccess ? 5.0 : (isError ? 7.0 : 8.0)
-                            let speed: Float     = isSuccess ? 900.0 : (isError ? 800.0 : 1000.0)
-
-                            ZStack {
-                                // Background
-                                ZStack {
-                                    Color.black
-                                    Circle()
-                                        .fill(
-                                            (isError
-                                                ? Color(red: 0.91, green: 0.66, blue: 0.09)
-                                                : Color(red: 0.20, green: 0.764, blue: 0.388))
-                                            .opacity(isSuccess ? 0.6 : (isError ? 0.5 : 0.3))
-                                        )
-                                        .frame(width: 160)
-                                        .blur(radius: isError ? 35 : 40)
-                                        .offset(x: -40, y: -20)
-                                    Circle()
-                                        .fill(Color.white.opacity(0.15))
-                                        .frame(width: 140)
-                                        .blur(radius: 40)
-                                        .offset(x: 50, y: 30)
-                                }
-                                .scaleEffect(1.2)
-                                .layerEffect(
-                                    ShaderLibrary.modernFluid(
-                                        .float(elapsedTime),
-                                        .float2(Float(geo.size.width), Float(geo.size.height))
-                                    ),
-                                    maxSampleOffset: CGSize(width: 10, height: 10)
-                                )
-
-                                // Foreground
-                                VStack(spacing: 12) {
-                                    Spacer()
-
-                                    if processor.isSuccess {
-                                        Image(systemName: "checkmark.circle.fill")
-                                            .font(.system(size: 42))
-                                            .foregroundColor(Color(red: 0.2, green: 0.8, blue: 0.4))
-                                            .shadow(color: Color(red: 0.2, green: 0.8, blue: 0.4).opacity(0.5), radius: 8, x: 0, y: 0)
-                                            .transition(.scale.combined(with: .opacity))
-
-                                        Text("SUCCESS")
-                                            .font(.system(size: 12, weight: .bold, design: .rounded))
-                                            .tracking(2.0)
-                                            .foregroundColor(.white)
-                                            .padding(.bottom, 16)
-                                            .transition(.opacity)
-                                    } else if processor.isError {
-                                        ErrorIconView()
-                                            .transition(.scale.combined(with: .opacity))
-
-                                        Text("FAILED")
-                                            .font(.system(size: 12, weight: .bold, design: .rounded))
-                                            .tracking(2.0)
-                                            .foregroundColor(.white)
-                                            .padding(.bottom, 16)
-                                            .transition(.opacity)
-                                    } else {
-                                        FannedImageStack(images: processor.processingImages)
-                                            .transition(.scale.combined(with: .opacity))
-
-                                        Text("PROCESSING \(processor.activeFormat == .png ? "PNG" : "WEBP")")
-                                            .font(.system(size: 11, weight: .bold, design: .rounded))
-                                            .tracking(1.5)
-                                            .foregroundColor(.white.opacity(0.9))
-                                            .padding(.bottom, 16)
-                                            .transition(.opacity)
-                                    }
-                                }
-                                .animation(.spring(response: 0.10, dampingFraction: 0.65), value: processor.isSuccess)
-                                .animation(.spring(response: 0.08, dampingFraction: 0.70), value: processor.isError)
-                            }
-                            .layerEffect(
-                                ShaderLibrary.Ripple(
-                                    .float2(Float(geo.size.width / 2), Float(geo.size.height / 2)),
-                                    .float(Float(rippleTime)),
-                                    .float(amplitude),
-                                    .float(frequency),
-                                    .float(decay),
-                                    .float(speed)
-                                ),
-                                maxSampleOffset: CGSize(width: 40, height: 40),
-                                isEnabled: true
-                            )
-                        }
-                        .transition(.opacity)
-                    }
-                }
-                .allowsHitTesting(processor.isProcessing)
+                ProcessingLayerView(processor: processor)
                 
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -251,16 +288,7 @@ struct DropZoneView: View {
             .padding(2)
             .overlay(
                 RoundedRectangle(cornerRadius: 12)
-                    .stroke(
-                        processor.isProcessing
-                            ? (processor.isSuccess
-                                ? Color.green.opacity(0.4)
-                                : (processor.isError
-                                    ? Color(red: 0.91, green: 0.66, blue: 0.09).opacity(0.4)
-                                    : Color.white.opacity(0.3)))
-                            : Color.white.opacity(0.15),
-                        style: StrokeStyle(lineWidth: 2, dash: [6, 6])
-                    )
+                    .stroke(borderStrokeColor, style: StrokeStyle(lineWidth: 2, dash: [6, 6]))
                     .animation(.easeInOut, value: processor.isProcessing)
             )
             .padding(12)
@@ -287,3 +315,4 @@ struct DropZoneView: View {
         return true
     }
 }
+

--- a/ImageProcessor.swift
+++ b/ImageProcessor.swift
@@ -23,6 +23,8 @@ class ImageProcessor: ObservableObject {
     @Published var processingStartTime: Date = Date()
     @Published var successStartTime: Date = Date()
     @Published var processingImages: [NSImage] = []
+    @Published var isError = false
+    @Published var errorStartTime: Date = Date()
     
     func processDroppedURLs(_ urls: [URL], to targetFormat: TargetFormat) {
         let previewCount = min(urls.count, 3)
@@ -69,12 +71,21 @@ class ImageProcessor: ObservableObject {
                         }
                     }
                 } else {
-                    // FAILURE STATE: Abort immediately without showing Success checkmark
-                    print("Processing failed. Aborting UI.")
-                    withAnimation(.easeInOut(duration: 0.5)) {
-                        self.isProcessing = false
-                        self.activeFormat = nil
-                        self.processingImages = []
+                    withAnimation(.spring(response: 0.08, dampingFraction: 0.70)) {
+                        self.isError = true
+                        self.errorStartTime = Date()
+                    }
+
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 3.5) {
+                        withAnimation(.easeInOut(duration: 0.5)) {
+                            self.isProcessing = false
+                        }
+
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                            self.isError = false
+                            self.activeFormat = nil
+                            self.processingImages = []
+                        }
                     }
                 }
             }

--- a/ImageProcessor.swift
+++ b/ImageProcessor.swift
@@ -36,6 +36,7 @@ class ImageProcessor: ObservableObject {
         withAnimation(.easeInOut(duration: 0.3)) {
             self.isProcessing = true
             self.isSuccess = false
+            self.isError = false
             self.activeFormat = targetFormat
             self.processingStartTime = Date()
             self.processingImages = thumbnails
@@ -83,6 +84,7 @@ class ImageProcessor: ObservableObject {
                         }
 
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                            guard !self.isProcessing else { return }
                             self.isError = false
                             self.activeFormat = nil
                             self.processingImages = []

--- a/ImageProcessor.swift
+++ b/ImageProcessor.swift
@@ -65,6 +65,7 @@ class ImageProcessor: ObservableObject {
                         }
                         
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                            guard !self.isProcessing else { return }
                             self.isSuccess = false
                             self.activeFormat = nil
                             self.processingImages = []


### PR DESCRIPTION
# Changes

Addressing #1 with a simple fix; inspired from the existing 'success' UI.

#### Before

No visual feedback for when processing fails.

https://github.com/user-attachments/assets/8a85e743-a2b9-4dce-8608-d37f4daae86d

#### After

Visual feedback when processing fails 

https://github.com/user-attachments/assets/4269834c-e00c-4fb7-840e-5a99f5c69c20



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Animated error feedback: a shaking warning icon, "FAILED" label, and orange-tinted processing visuals when image processing fails
  * Staged error flow that shows the error state briefly before automatically resetting

* **Improvements**
  * Refined processing animations and timing (separate spring for success vs. error, adjusted ripple/blur/opacity)
  * Introduced a shared amber color for error visuals and updated border/overlay tinting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->