### PR TITLE
Add timeout mechanism and error feedback for image processing

### DIFF
--- a/DropZoneView.swift
+++ b/DropZoneView.swift
@@ -164,6 +164,26 @@ struct DropZoneView: View {
                                             .foregroundColor(.white)
                                             .padding(.bottom, 16)
                                             .transition(.opacity)
+                                    } else if processor.isError {
+                                        Image(systemName: "exclamationmark.triangle.fill")
+                                            .font(.system(size: 42))
+                                            .foregroundColor(Color.red.opacity(0.8))
+                                            .shadow(color: Color.red.opacity(0.5), radius: 8, x: 0, y: 0)
+                                            .transition(.scale.combined(with: .opacity))
+
+                                        Text("FAILED")
+                                            .font(.system(size: 12, weight: .bold, design: .rounded))
+                                            .tracking(2.0)
+                                            .foregroundColor(.white)
+                                            .padding(.bottom, 8)
+                                            .transition(.opacity)
+
+                                        Text(processor.errorMessage)
+                                            .font(.system(size: 10, weight: .medium, design: .rounded))
+                                            .foregroundColor(.white.opacity(0.7))
+                                            .multilineTextAlignment(.center)
+                                            .padding(.horizontal, 16)
+                                            .transition(.opacity)
                                     } else {
                                         FannedImageStack(images: processor.processingImages)
                                             .transition(.scale.combined(with: .opacity))
@@ -203,7 +223,7 @@ struct DropZoneView: View {
             .padding(2)
             .overlay(
                 RoundedRectangle(cornerRadius: 12)
-                    .stroke(processor.isProcessing ? (processor.isSuccess ? Color.green.opacity(0.4) : Color.white.opacity(0.3)) : Color.white.opacity(0.15), style: StrokeStyle(lineWidth: 2, dash: [6, 6]))
+                    .stroke(processor.isProcessing ? (processor.isSuccess ? Color.green.opacity(0.4) : (processor.isError ? Color.red.opacity(0.4) : Color.white.opacity(0.3))) : Color.white.opacity(0.15), style: StrokeStyle(lineWidth: 2, dash: [6, 6]))
                     .animation(.easeInOut, value: processor.isProcessing)
             )
             .padding(12)

--- a/DropZoneView.swift
+++ b/DropZoneView.swift
@@ -108,9 +108,9 @@ struct DropZoneView: View {
                 .allowsHitTesting(!processor.isProcessing) // Disables drops when hidden
                 
                 
-                // LAYER 2: COMBINED PROCESSING ZONE (Fades in when processing)
+                // LAYER 2: COMBINED PROCESSING ZONE (Fades in when processing or error)
                 GeometryReader { geo in
-                    if processor.isProcessing {
+                    if processor.isProcessing || processor.isError {
                         TimelineView(.animation(minimumInterval: 1/60)) { timeline in
                             let elapsedTime = timeline.date.timeIntervalSince(processor.processingStartTime)
                             let dropTime = elapsedTime.truncatingRemainder(dividingBy: 2.0)
@@ -197,6 +197,7 @@ struct DropZoneView: View {
                                     }
                                 }
                                 .animation(.spring(response: 0.10, dampingFraction: 0.65), value: processor.isSuccess)
+                                .animation(.spring(response: 0.10, dampingFraction: 0.65), value: processor.isError)
                             }
                             .layerEffect(
                                 ShaderLibrary.Ripple(

--- a/ImageProcessor.swift
+++ b/ImageProcessor.swift
@@ -27,12 +27,16 @@ class ImageProcessor: ObservableObject {
     @Published var processingImages: [NSImage] = []
     
     private let processingTimeout: TimeInterval = 60
+    private var currentRunID = UUID()
     
     /// Processes dropped image URLs and converts them to the target format.
     /// - Parameters:
     ///   - urls: Array of file URLs to process
     ///   - targetFormat: Target image format (PNG or WebP)
     func processDroppedURLs(_ urls: [URL], to targetFormat: TargetFormat) {
+        let runID = UUID()
+        self.currentRunID = runID
+        
         let previewCount = min(urls.count, 3)
         var thumbnails: [NSImage] = []
         for i in 0..<previewCount {
@@ -42,6 +46,8 @@ class ImageProcessor: ObservableObject {
         withAnimation(.easeInOut(duration: 0.3)) {
             self.isProcessing = true
             self.isSuccess = false
+            self.isError = false
+            self.errorMessage = ""
             self.activeFormat = targetFormat
             self.processingStartTime = Date()
             self.processingImages = thumbnails
@@ -69,6 +75,8 @@ class ImageProcessor: ObservableObject {
             }
             
             DispatchQueue.main.async {
+                guard self.currentRunID == runID else { return }
+                
                 if allSucceeded && !urls.isEmpty {
                     // 1. Files physically exist. Trigger Success State.
                     withAnimation(.spring(response: 0.25, dampingFraction: 0.65)) {
@@ -78,11 +86,13 @@ class ImageProcessor: ObservableObject {
                     
                     // 2. Hide UI after 3.5 seconds
                     DispatchQueue.main.asyncAfter(deadline: .now() + 3.5) {
+                        guard self.currentRunID == runID else { return }
                         withAnimation(.easeInOut(duration: 0.5)) {
                             self.isProcessing = false
                         }
                         
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                            guard self.currentRunID == runID else { return }
                             self.isSuccess = false
                             self.isError = false
                             self.errorMessage = ""
@@ -103,10 +113,10 @@ class ImageProcessor: ObservableObject {
                         self.processingImages = []
                     }
                     
-                    // Auto-clear error after 3 seconds (check to avoid race condition)
-                    let errorMsgToClear = errorMsg
+                    // Auto-clear error after 3 seconds
                     DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                        if self.errorMessage == errorMsgToClear {
+                        guard self.currentRunID == runID else { return }
+                        if self.isError {
                             withAnimation {
                                 self.isError = false
                                 self.errorMessage = ""
@@ -207,7 +217,10 @@ class ImageProcessor: ObservableObject {
             if !fileExists {
                 return ProcessResult(success: false, timedOut: false, errorMessage: "WebP file was not created")
             }
-            return ProcessResult(success: result.success, timedOut: false, errorMessage: nil)
+            guard result.success else {
+                return ProcessResult(success: false, timedOut: false, errorMessage: "WebP conversion failed")
+            }
+            return ProcessResult(success: true, timedOut: false, errorMessage: nil)
             
         } else {
             // STEP 1: Lossy Color Quantization (pngquant)
@@ -249,7 +262,10 @@ class ImageProcessor: ObservableObject {
             if result2.timedOut {
                 return ProcessResult(success: true, timedOut: false, errorMessage: nil) // Step 1 still succeeded
             }
-            return ProcessResult(success: result2.success, timedOut: false, errorMessage: nil)
+            guard result2.success else {
+                return ProcessResult(success: true, timedOut: false, errorMessage: "PNG optimization failed")
+            }
+            return ProcessResult(success: true, timedOut: false, errorMessage: nil)
         }
     }
 }

--- a/ImageProcessor.swift
+++ b/ImageProcessor.swift
@@ -19,10 +19,14 @@ enum TargetFormat: Equatable {
 class ImageProcessor: ObservableObject {
     @Published var isProcessing = false
     @Published var isSuccess = false
+    @Published var isError = false
+    @Published var errorMessage: String = ""
     @Published var activeFormat: TargetFormat? = nil
     @Published var processingStartTime: Date = Date()
     @Published var successStartTime: Date = Date()
     @Published var processingImages: [NSImage] = []
+    
+    private let processingTimeout: TimeInterval = 60
     
     func processDroppedURLs(_ urls: [URL], to targetFormat: TargetFormat) {
         let previewCount = min(urls.count, 3)
@@ -41,11 +45,23 @@ class ImageProcessor: ObservableObject {
         
         DispatchQueue.global(qos: .userInitiated).async {
             var allSucceeded = true
+            var lastError: String = ""
+            var didTimeout = false
             
             // Track actual success for each file
             for url in urls {
-                let success = self.executeShellPipeline(sourceURL: url, targetFormat: targetFormat)
-                if !success { allSucceeded = false }
+                let result = self.executeShellPipeline(sourceURL: url, targetFormat: targetFormat)
+                if !result.success {
+                    allSucceeded = false
+                    if result.timedOut {
+                        didTimeout = true
+                        lastError = "Processing timed out"
+                    } else if let error = result.errorMessage {
+                        lastError = error
+                    } else {
+                        lastError = "Unknown error"
+                    }
+                }
             }
             
             DispatchQueue.main.async {
@@ -64,17 +80,31 @@ class ImageProcessor: ObservableObject {
                         
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
                             self.isSuccess = false
+                            self.isError = false
+                            self.errorMessage = ""
                             self.activeFormat = nil
                             self.processingImages = []
                         }
                     }
                 } else {
                     // FAILURE STATE: Abort immediately without showing Success checkmark
-                    print("Processing failed. Aborting UI.")
+                    let errorMsg = didTimeout ? "Processing timed out after \(Int(self.processingTimeout)) seconds" : lastError
+                    print("Processing failed: \(errorMsg). Aborting UI.")
+                    
                     withAnimation(.easeInOut(duration: 0.5)) {
+                        self.isError = true
+                        self.errorMessage = errorMsg
                         self.isProcessing = false
                         self.activeFormat = nil
                         self.processingImages = []
+                    }
+                    
+                    // Auto-clear error after 3 seconds
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                        withAnimation {
+                            self.isError = false
+                            self.errorMessage = ""
+                        }
                     }
                 }
             }
@@ -91,7 +121,49 @@ class ImageProcessor: ObservableObject {
         }
     }
     
-    private func executeShellPipeline(sourceURL: URL, targetFormat: TargetFormat) -> Bool {
+    // MARK: - Process with Timeout
+    /// Runs a process with a timeout. Returns true if process completed successfully within timeout.
+    private func runProcessWithTimeout(_ process: Process, timeout: TimeInterval = 60) -> (success: Bool, timedOut: Bool) {
+        let workItem = DispatchWorkItem {
+            process.terminate()
+        }
+        
+        var didTimeout = false
+        
+        do {
+            try process.run()
+            
+            let result = DispatchSemaphore(value: 0)
+            let timeoutWorkItem = DispatchWorkItem {
+                if process.isRunning {
+                    process.terminate()
+                    didTimeout = true
+                }
+                result.signal()
+            }
+            
+            DispatchQueue.global().asyncAfter(deadline: .now() + timeout, execute: timeoutWorkItem)
+            result.wait()
+            timeoutWorkItem.cancel()
+            
+            if didTimeout {
+                return (false, true)
+            }
+            
+            process.waitUntilExit()
+            return (process.terminationStatus == 0, false)
+        } catch {
+            return (false, false)
+        }
+    }
+    
+    private struct ProcessResult {
+        var success: Bool
+        var timedOut: Bool
+        var errorMessage: String?
+    }
+    
+    private func executeShellPipeline(sourceURL: URL, targetFormat: TargetFormat) -> ProcessResult {
         // 1. Define and Create Output Directory
         let parentDirectory = sourceURL.deletingLastPathComponent()
         let optimizedDirectory = parentDirectory.appendingPathComponent("Optimized Files")
@@ -100,13 +172,17 @@ class ImageProcessor: ObservableObject {
             if !FileManager.default.fileExists(atPath: optimizedDirectory.path) {
                 try FileManager.default.createDirectory(at: optimizedDirectory, withIntermediateDirectories: true, attributes: nil)
             }
-        } catch { return false }
+        } catch { 
+            return ProcessResult(success: false, timedOut: false, errorMessage: "Failed to create output directory") 
+        }
         
         // 2. Keep Exact Original Filename
         let originalName = sourceURL.deletingPathExtension().lastPathComponent
         
         if targetFormat == .webp {
-            guard let cwebpPath = Bundle.main.path(forResource: "cwebp", ofType: nil) else { return false }
+            guard let cwebpPath = Bundle.main.path(forResource: "cwebp", ofType: nil) else { 
+                return ProcessResult(success: false, timedOut: false, errorMessage: "cwebp binary not found") 
+            }
             grantExecutablePermissions(to: cwebpPath)
             
             let finalURL = optimizedDirectory.appendingPathComponent(originalName).appendingPathExtension("webp")
@@ -117,15 +193,21 @@ class ImageProcessor: ObservableObject {
             // Upgraded: Added -m 6 (max compression) and -mt (multi-threading)
             process.arguments = ["-q", "\(webpQ)", "-m", "6", "-mt", sourceURL.path, "-o", finalURL.path]
             
-            do {
-                try process.run()
-                process.waitUntilExit()
-                return FileManager.default.fileExists(atPath: finalURL.path)
-            } catch { return false }
+            let result = runProcessWithTimeout(process, timeout: processingTimeout)
+            if result.timedOut {
+                return ProcessResult(success: false, timedOut: true, errorMessage: "WebP conversion timed out")
+            }
+            let fileExists = FileManager.default.fileExists(atPath: finalURL.path)
+            if !fileExists {
+                return ProcessResult(success: false, timedOut: false, errorMessage: "WebP file was not created")
+            }
+            return ProcessResult(success: result.success, timedOut: false, errorMessage: nil)
             
         } else {
             // STEP 1: Lossy Color Quantization (pngquant)
-            guard let pngquantPath = Bundle.main.path(forResource: "pngquant", ofType: nil) else { return false }
+            guard let pngquantPath = Bundle.main.path(forResource: "pngquant", ofType: nil) else { 
+                return ProcessResult(success: false, timedOut: false, errorMessage: "pngquant binary not found") 
+            }
             grantExecutablePermissions(to: pngquantPath)
             
             let finalURL = optimizedDirectory.appendingPathComponent(originalName).appendingPathExtension("png")
@@ -137,15 +219,19 @@ class ImageProcessor: ObservableObject {
             // Upgraded: Added --speed 1 (max effort) and --strip (removes metadata bloat)
             process1.arguments = ["--quality=\(pngMin)-\(pngMax)", "--speed", "1", "--strip", "--force", sourceURL.path, "--output", finalURL.path]
             
-            do {
-                try process1.run()
-                process1.waitUntilExit()
-                guard process1.terminationStatus == 0 && FileManager.default.fileExists(atPath: finalURL.path) else { return false }
-            } catch { return false }
+            let result1 = runProcessWithTimeout(process1, timeout: processingTimeout)
+            if result1.timedOut {
+                return ProcessResult(success: false, timedOut: true, errorMessage: "PNG quantization timed out")
+            }
+            guard result1.success && FileManager.default.fileExists(atPath: finalURL.path) else { 
+                return ProcessResult(success: false, timedOut: false, errorMessage: "PNG quantization failed") 
+            }
             
             // STEP 2: Lossless Deflation (oxipng)
             // Fails silently and returns the pngquant version if oxipng isn't bundled yet
-            guard let oxipngPath = Bundle.main.path(forResource: "oxipng", ofType: nil) else { return true }
+            guard let oxipngPath = Bundle.main.path(forResource: "oxipng", ofType: nil) else { 
+                return ProcessResult(success: true, timedOut: false, errorMessage: nil) 
+            }
             grantExecutablePermissions(to: oxipngPath)
             
             let process2 = Process()
@@ -153,11 +239,11 @@ class ImageProcessor: ObservableObject {
             // -o 4 is optimal max effort. Overwrites the file in-place.
             process2.arguments = ["-o", "4", "--strip", "safe", finalURL.path]
             
-            do {
-                try process2.run()
-                process2.waitUntilExit()
-                return process2.terminationStatus == 0
-            } catch { return true } // Return true because Step 1 still succeeded
+            let result2 = runProcessWithTimeout(process2, timeout: processingTimeout)
+            if result2.timedOut {
+                return ProcessResult(success: true, timedOut: false, errorMessage: nil) // Step 1 still succeeded
+            }
+            return ProcessResult(success: result2.success, timedOut: false, errorMessage: nil)
         }
     }
 }

--- a/ImageProcessor.swift
+++ b/ImageProcessor.swift
@@ -28,6 +28,10 @@ class ImageProcessor: ObservableObject {
     
     private let processingTimeout: TimeInterval = 60
     
+    /// Processes dropped image URLs and converts them to the target format.
+    /// - Parameters:
+    ///   - urls: Array of file URLs to process
+    ///   - targetFormat: Target image format (PNG or WebP)
     func processDroppedURLs(_ urls: [URL], to targetFormat: TargetFormat) {
         let previewCount = min(urls.count, 3)
         var thumbnails: [NSImage] = []
@@ -99,11 +103,14 @@ class ImageProcessor: ObservableObject {
                         self.processingImages = []
                     }
                     
-                    // Auto-clear error after 3 seconds
+                    // Auto-clear error after 3 seconds (check to avoid race condition)
+                    let errorMsgToClear = errorMsg
                     DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                        withAnimation {
-                            self.isError = false
-                            self.errorMessage = ""
+                        if self.errorMessage == errorMsgToClear {
+                            withAnimation {
+                                self.isError = false
+                                self.errorMessage = ""
+                            }
                         }
                     }
                 }
@@ -112,7 +119,8 @@ class ImageProcessor: ObservableObject {
     }
     
     // MARK: - Hardened Runtime Fix
-    /// Programmatically forces macOS to treat the binary as an executable, bypassing Archive stripping
+    /// Programmatically forces macOS to treat the binary as an executable, bypassing Archive stripping.
+    /// - Parameter path: The file path to the binary
     private func grantExecutablePermissions(to path: String) {
         do {
             try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: path)
@@ -122,47 +130,45 @@ class ImageProcessor: ObservableObject {
     }
     
     // MARK: - Process with Timeout
-    /// Runs a process with a timeout. Returns true if process completed successfully within timeout.
+    /// Runs a process with a timeout. Returns success status and whether it timed out.
+    /// - Parameters:
+    ///   - process: The Process to run
+    ///   - timeout: Maximum time to wait in seconds (default 60)
+    /// - Returns: Tuple containing success (bool) and timedOut (bool)
     private func runProcessWithTimeout(_ process: Process, timeout: TimeInterval = 60) -> (success: Bool, timedOut: Bool) {
-        let workItem = DispatchWorkItem {
-            process.terminate()
-        }
+        let semaphore = DispatchSemaphore(value: 0)
         
-        var didTimeout = false
+        process.terminationHandler = { _ in
+            semaphore.signal()
+        }
         
         do {
             try process.run()
-            
-            let result = DispatchSemaphore(value: 0)
-            let timeoutWorkItem = DispatchWorkItem {
-                if process.isRunning {
-                    process.terminate()
-                    didTimeout = true
-                }
-                result.signal()
-            }
-            
-            DispatchQueue.global().asyncAfter(deadline: .now() + timeout, execute: timeoutWorkItem)
-            result.wait()
-            timeoutWorkItem.cancel()
-            
-            if didTimeout {
-                return (false, true)
-            }
-            
-            process.waitUntilExit()
-            return (process.terminationStatus == 0, false)
         } catch {
             return (false, false)
         }
+        
+        let timeoutResult = semaphore.wait(timeout: .now() + timeout)
+        
+        if timeoutResult == .timedOut {
+            if process.isRunning {
+                process.terminate()
+                process.waitUntilExit()
+            }
+            return (false, true)
+        }
+        
+        return (process.terminationStatus == 0, false)
     }
     
+    /// Result structure for shell pipeline execution
     private struct ProcessResult {
         var success: Bool
         var timedOut: Bool
         var errorMessage: String?
     }
     
+    /// Executes the shell pipeline to convert an image to the target format
     private func executeShellPipeline(sourceURL: URL, targetFormat: TargetFormat) -> ProcessResult {
         // 1. Define and Create Output Directory
         let parentDirectory = sourceURL.deletingLastPathComponent()

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,1 @@
+testing personal github push

--- a/test.txt
+++ b/test.txt
@@ -1,1 +1,0 @@
-testing personal github push


### PR DESCRIPTION
## Summary

This PR adds timeout handling and proper error feedback to fix issue #3.

### Changes Made

1. **Timeout mechanism** - Added 60 second timeout to shell execution for external image tools (cwebp, pngquant, oxipng). If any tool hangs or takes too long, the app now gracefully handles it instead of hanging indefinitely.

2. **Error feedback UI** - Users now see a clear error state when processing fails, including:
   - Red warning icon with "FAILED" message
   - Specific error message (e.g., "cwebp binary not found", "PNG quantization failed", "Processing timed out")
   - Red border on the popover during error state
   - Auto-dismisses after 3 seconds

### Why this matters

Previously, when image processing failed, the app would silently fail with no user feedback. Users had no idea if processing worked or failed. Now they get clear feedback about what went wrong.

### Testing

- Tested that timeout terminates stuck processes
- Tested error state displays correctly
- Tested error auto-clears after 3 seconds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visual error UI during processing: red warning icon, "FAILED" label, and detailed error message.
  * Processing state now differentiates success and error with matching animations and border color.

* **Bug Fixes / Improvements**
  * Aggregated and clearer error reporting for conversion failures and timeouts.
  * Automatic error message clearance after 3 seconds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->