### PR TITLE
fix: download url for dmg file in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ https://github.com/user-attachments/assets/de94b2fd-c711-46d1-b790-6626954f07af
 
 ```bash
 curl -L -o Burrito.dmg \
-  https://github.com/saranonearth/Burrito/releases/download/v1.0.0/Burrito.dmg
+  https://github.com/SwishHQ/burrito/releases/latest/download/Burrito.dmg
 open Burrito.dmg
 ```
 


### PR DESCRIPTION
updated the download url in readme file to always point to the latest tag 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated installation instructions to download the latest release build from the official repository, ensuring users receive the current version when installing via command line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->